### PR TITLE
fix: exclude win arm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,9 +71,9 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             name: windows-amd64
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-            name: windows-arm64
+          # - os: windows-latest
+          #   target: aarch64-pc-windows-msvc
+          #   name: windows-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             name: macos-amd64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration
	- Removed Windows ARM64 build target from release process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->