### PR TITLE
fix: use gcc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,10 +69,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             name: linux-amd64
           - os: windows-latest
-            target: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-gcc
             name: windows-amd64
           # - os: windows-latest
-          #   target: aarch64-pc-windows-msvc
+          #   target: aarch64-pc-windows-gcc
           #   name: windows-arm64
           - os: macos-latest
             target: x86_64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,6 +90,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install MinGW-w64 (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+
       - name: Cache cargo and build files
         uses: actions/cache@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for Windows build targets
	- Switched Windows build toolchain from MSVC to GCC for x86_64 and aarch64 architectures
	- Added installation step for the MinGW-w64 toolchain for Windows builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->