### PR TITLE
fix: only zip for debug viewer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,7 +193,7 @@ jobs:
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
             cp "target/${{ matrix.target }}/release/ridi-router.exe" "dist/ridi-router-${{ matrix.name }}.exe"
             cd dist
-            tar -a -c -f "ridi-router-${{ matrix.name }}.zip" "ridi-router-${{ matrix.name }}.exe"
+             powershell Compress-Archive "ridi-router-${{ matrix.name }}.exe" "ridi-router-${{ matrix.name }}.zip"
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
             # Binary already in dist from build step
             cd dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: binary-debug-viewer-linux-amd64
-          path: dist/*
+          path: dist/*.zip
 
   build:
     needs: prepare-version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow configuration for more precise artifact handling
  - Refined binary upload process to use only zipped artifacts
  - Improved release workflow artifact management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->