### PR TITLE
fix: check if stuck before move back not after

### DIFF
--- a/src/router/navigator.rs
+++ b/src/router/navigator.rs
@@ -271,19 +271,6 @@ impl Navigator {
                     self.walker.set_fork_choice_point_ref(chosen_fork_point);
                 } else {
                     if self
-                        .itinerary
-                        .check_set_back(self.walker.get_last_point().clone())
-                    {
-                        self.discarded_fork_choices.set_prev_next();
-                    }
-                    self.walker.move_backwards_to_prev_fork();
-                    DebugWriter::write_step_result(
-                        self.itinerary.id(),
-                        loop_counter,
-                        "MoveBack",
-                        None,
-                    );
-                    if self
                         .walker
                         .get_route()
                         .get_junction_before_last_segment()
@@ -298,6 +285,19 @@ impl Navigator {
                         );
                         return NavigationResult::Stuck;
                     }
+                    if self
+                        .itinerary
+                        .check_set_back(self.walker.get_last_point().clone())
+                    {
+                        self.discarded_fork_choices.set_prev_next();
+                    }
+                    self.walker.move_backwards_to_prev_fork();
+                    DebugWriter::write_step_result(
+                        self.itinerary.id(),
+                        loop_counter,
+                        "MoveBack",
+                        None,
+                    );
                 }
             } else if move_result == Ok(WalkerMoveResult::DeadEnd) {
                 DebugWriter::write_step_result(self.itinerary.id(), loop_counter, "MoveBack", None);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved routing logic control flow in the navigation system
	- Reordered code to prioritize handling of previous route choices before checking for stuck conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->