### PR TITLE
fix: not allow loops on start-finish

### DIFF
--- a/src/debug/writer.rs
+++ b/src/debug/writer.rs
@@ -80,7 +80,6 @@ pub struct DebugStreamItineraries {
     pub waypoints_count: i64,
     #[typeshare(serialized_as = "number")]
     pub radius: i64,
-    pub visit_all: bool,
     pub start_lat: f32,
     pub start_lon: f32,
     pub finish_lat: f32,
@@ -343,7 +342,6 @@ impl DebugWriter {
                         itinerary_id: itinerary.id(),
                         waypoints_count: itinerary.waypoints.len() as i64,
                         radius: itinerary.waypoint_radius as i64,
-                        visit_all: itinerary.visit_all_waypoints,
                         start_lat: itinerary.start.borrow().lat,
                         start_lon: itinerary.start.borrow().lon,
                         finish_lat: itinerary.finish.borrow().lat,

--- a/src/router/itinerary.rs
+++ b/src/router/itinerary.rs
@@ -15,8 +15,8 @@ pub struct Itinerary {
     pub waypoints: Vec<MapDataPointRef>,
     pub next: MapDataPointRef,
     pub waypoint_radius: f32,
-    pub visit_all_waypoints: bool,
     pub switched_wps_on: Vec<WaypointHistoryElement>,
+    pub check_loop_since_last_wp: bool,
 }
 
 impl Display for Itinerary {
@@ -48,8 +48,8 @@ impl Itinerary {
             next: waypoints.first().map_or(finish.clone(), |w| w.clone()),
             waypoints,
             finish,
-            visit_all_waypoints: false,
             switched_wps_on: Vec::new(),
+            check_loop_since_last_wp: false,
         }
     }
     pub fn new_round_trip(
@@ -64,8 +64,8 @@ impl Itinerary {
             next: waypoints.first().map_or(finish.clone(), |w| w.clone()),
             waypoints,
             finish,
-            visit_all_waypoints: true,
             switched_wps_on: Vec::new(),
+            check_loop_since_last_wp: true,
         }
     }
 
@@ -80,6 +80,13 @@ impl Itinerary {
                 .join("-"),
             self.finish.borrow().id
         )
+    }
+
+    pub fn get_point_loop_check_since(&self) -> Option<&MapDataPointRef> {
+        if self.check_loop_since_last_wp {
+            return self.switched_wps_on.last().map(|v| &v.on_point);
+        }
+        Some(&self.start)
     }
 
     pub fn is_finished(&self, current: MapDataPointRef) -> bool {

--- a/src/router/weights.rs
+++ b/src/router/weights.rs
@@ -125,7 +125,7 @@ pub fn weight_no_loops(input: WeightCalcInput) -> WeightCalcResult {
     trace!("weight_no_loops");
     if input
         .route
-        .has_looped(input.itinerary.switched_wps_on.last().map(|v| &v.on_point))
+        .has_looped(input.itinerary.get_point_loop_check_since())
     {
         return WeightCalcResult::DoNotUse;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Routing Improvements**
    - Updated waypoint and loop checking mechanism in route planning.
    - Introduced new method for determining route loop status.
    - Modified internal logic for handling route waypoints.
    - Adjusted serialization logic for itinerary data by removing the `visit_all` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->